### PR TITLE
[Compat] support React@15.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,20 @@ npm i --save-dev enzyme
 Enzyme is currently compatible with `React 15.x`, `React 0.14.x` and `React 0.13.x`. In order to
 achieve this compatibility, some dependencies cannot be explicitly listed in our `package.json`.
 
-If you are using `React 0.14` or `React 15.x`, in addition to `enzyme`, you will have to ensure that
+If you are using `React 0.14` or `React <15.5`, in addition to `enzyme`, you will have to ensure that
 you also have the following npm modules installed if they were not already:
 
 ```bash
 npm i --save-dev react-addons-test-utils
 npm i --save-dev react-dom
+```
+
+If you are using `React >=15.5`, in addition to `enzyme`, you will have to ensure that you also have
+the following npm modules installed if they were not already:
+
+```bash
+npm i --save-dev react-dom
+npm i --save-dev prop-types
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react:clean": "rimraf node_modules/react node_modules/react-dom node_modules/react-addons-test-utils",
     "react:13": "rimraf node_modules/.bin/npm && npm run react:clean && npm i react@0.13 && npm install",
     "react:14": "rimraf node_modules/.bin/npm && npm run react:clean && npm i react@0.14 react-dom@0.14 react-addons-test-utils@0.14 && npm install",
-    "react:15": "rimraf node_modules/.bin/npm && npm run react:clean && npm i react@15 react-dom@15 react-addons-test-utils@15 && npm install",
+    "react:15": "rimraf node_modules/.bin/npm && npm run react:clean && npm i react@15 react-dom@15 react-addons-test-utils@15 prop-types@15 create-react-class@15 && npm install",
     "docs:clean": "rimraf _book",
     "docs:prepare": "gitbook install",
     "docs:build": "npm run docs:prepare && gitbook build",

--- a/src/ReactWrapperComponent.jsx
+++ b/src/ReactWrapperComponent.jsx
@@ -1,5 +1,6 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import objectAssign from 'object.assign';
+import { PropTypes, createClass } from './react-compat';
 
 /* eslint react/forbid-prop-types: 0 */
 
@@ -89,5 +90,5 @@ export default function createWrapperComponent(node, options = {}) {
     });
   }
 
-  return React.createClass(spec);
+  return createClass(spec);
 }

--- a/src/react-compat.js
+++ b/src/react-compat.js
@@ -7,7 +7,7 @@
 */
 
 import objectAssign from 'object.assign';
-import { REACT013 } from './version';
+import { REACT013, REACT155 } from './version';
 
 let TestUtils;
 let createShallowRenderer;
@@ -18,6 +18,8 @@ let childrenToArray;
 let renderWithOptions;
 let unmountComponentAtNode;
 let batchedUpdates;
+let PropTypes;
+let createClass;
 
 const React = require('react');
 
@@ -95,8 +97,13 @@ if (REACT013) {
   // to list this as a dependency in package.json and have 0.13 work properly.
   // As a result, right now this is basically an implicit dependency.
   try {
-    // eslint-disable-next-line import/no-extraneous-dependencies
-    TestUtils = require('react-addons-test-utils');
+    if (REACT155) {
+      // eslint-disable-next-line import/no-extraneous-dependencies
+      TestUtils = require('react-dom/test-utils');
+    } else {
+      // eslint-disable-next-line import/no-extraneous-dependencies
+      TestUtils = require('react-addons-test-utils');
+    }
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(
@@ -150,6 +157,16 @@ if (REACT013) {
   };
 }
 
+if (REACT155) {
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  PropTypes = require('prop-types');
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  createClass = require('create-react-class');
+} else {
+  PropTypes = React.PropTypes;
+  createClass = React.createClass;
+}
+
 function isDOMComponentElement(inst) {
   return React.isValidElement(inst) && typeof inst.type === 'string';
 }
@@ -185,4 +202,6 @@ export {
   renderWithOptions,
   unmountComponentAtNode,
   batchedUpdates,
+  PropTypes,
+  createClass,
 };

--- a/src/version.js
+++ b/src/version.js
@@ -4,3 +4,4 @@ export const VERSION = React.version;
 export const REACT013 = VERSION.slice(0, 4) === '0.13';
 export const REACT014 = VERSION.slice(0, 4) === '0.14';
 export const REACT15 = VERSION.slice(0, 3) === '15.';
+export const REACT155 = VERSION.slice(0, 4) === '15.5';


### PR DESCRIPTION
Pulling in Kent's fork

A few deprecation warnings were added in React@15.5. This supports the
new APIs that React recommends.
